### PR TITLE
Fix WS-FEDERATION button to use correct connection param

### DIFF
--- a/views/index.js
+++ b/views/index.js
@@ -604,7 +604,7 @@ $(function () {
     var url = 'https://' + $('#domain').val() + '/wsfed/' + $('#client_id').val() + '?wctx=' + encodeURIComponent($('#state').val());
     url = url + '&wreply=' + encodeURIComponent(callbackUrl);
     if ($('#connection').val() && $('#connection').val().length) {
-      url = url + '&wtrealm=' + encodeURIComponent($('#connection').val());
+      url = url + '&whr=' + encodeURIComponent($('#connection').val());
     }
     window.location.href = url;
   });


### PR DESCRIPTION
Per [Auth0 docs](https://auth0.com/docs/protocols/ws-fed#for-applications-clients-), the `whr` parameter is used to pass a connection (and skip the login page), not `wrealm`

## ✏️ Changes

Fixing a bug so that the WS-FEDERATION button, when clicked, uses the correct parameter for the Auth0 connection.

## 🔗 References
  
The [Auth0 docs](https://auth0.com/docs/protocols/ws-fed#for-applications-clients-).
  
## 🎯 Testing
  
Clicking the button with the change actually makes it work 😄 
   
🚫 This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
## 🎡 Rollout
  
In order to verify that the deployment was successful we will manually test.
