### PR TITLE
DXEX-56: Renew token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - Unreleased
+
+### Changed
+- App will re-login automatically on token expiration
+
 ## [2.0.1] - 2019-02-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.2] - Unreleased
+## [2.0.2] - 2019-06-13
 
 ### Changed
 - App will re-login automatically on token expiration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-authentication-api-debugger-extension",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "My extension for ..",
   "main": "index.js",
   "scripts": {

--- a/server/views/index.js
+++ b/server/views/index.js
@@ -577,6 +577,12 @@ $(function () {
         bindClients();
         read();
         setSelectedClientSecrets();
+    }).fail(function(err) {
+      if (err.status === 401 || err.status === 403) {
+        sessionStorage.removeItem('token');
+        sessionStorage.removeItem('apiToken');
+        window.location.href = '/login';
+      }
     });
 
   if ("{{method}}" === 'POST' || (window.location.hash && window.location.hash.length > 1) || (window.location.search && window.location.search.length > 1 && window.location.search !== '?webtask_no_cache=1')) {

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Auth0 Authentication API Debugger",
   "name": "auth0-authentication-api-debugger",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "auth0",
   "useHashName": false,
   "description": "This extension allows you to test and debug the various Authentication API endpoints",


### PR DESCRIPTION
## ✏️ Changes
  Extension is using access token to load list of apps form API2. If that request fails with 401 or 403 error, extension will try to get new token by re-login.
  
## 🔗 References
  Jira: https://auth0team.atlassian.net/browse/DXEX-56
  
## 🎯 Testing
✅This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  