### PR TITLE
Added code_verifier for PKCE support

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -54,7 +54,8 @@ module.exports = (configProvider) => {
     app.post('/request/code', function(req, res) {
         const data = {
           code: req.body.code,
-          redirect_uri: req.body.redirect_uri
+          redirect_uri: req.body.redirect_uri,
+          code_verifier: req.body.code_verifier
         };
         const auth0 = new AuthenticationClient({
           domain: config('AUTH0_DOMAIN'),


### PR DESCRIPTION
The code_verifier is provided by the client when using PKCE, but was missing in the POST to the token endpoint.
This PR adds support for the code_verifier, so that the code exchange with PKCE works.