### PR TITLE
Ensure token was issued by the RTA.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-authentication-api-debugger-extension",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "My extension for ..",
   "main": "index.js",
   "scripts": {

--- a/server/middleware/dashboardAdmins.js
+++ b/server/middleware/dashboardAdmins.js
@@ -1,5 +1,6 @@
 const url = require('url');
 const auth0 = require('auth0-oauth2-express');
+const jwt = require('jsonwebtoken');
 
 module.exports = function(domain, title, rta) {
   if (!domain) throw new Error('Domain is required');
@@ -12,7 +13,23 @@ module.exports = function(domain, title, rta) {
     audience: function() {
       return 'https://' + domain + '/api/v2/';
     },
-    rootTenantAuthority: rta
+    rootTenantAuthority: rta,
+    authenticatedCallback: function (req, res, accessToken, next) {
+      /**
+       * Note: We're normalizing the issuer because the access token `iss`
+       * ends in a slash whereas the `AUTH0_RTA` secret does not.
+       */
+      var expectedIssuer = rta.endsWith("/") ? rta : rta + "/";
+      var dtoken = jwt.decode(accessToken) || {};
+
+      if (dtoken.iss !== expectedIssuer) {
+        res.status(500);
+        return res.json({
+          message: "jwt issuer invalid. expected: " + expectedIssuer
+        });
+      }
+      return next();
+    },
   };
 
   const middleware = auth0(options);

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,8 @@
 {
   "title": "Auth0 Authentication API Debugger",
   "name": "auth0-authentication-api-debugger",
-  "version": "2.1.1",
+  "version": "2.1.2",
+  "preVersion": "2.1.1",
   "author": "auth0",
   "useHashName": false,
   "description": "This extension allows you to test and debug the various Authentication API endpoints",


### PR DESCRIPTION
## ✏️ Changes
  
We were not verifying the access token's issuer to be the RTA previously, so any valid token would allow the extension to be launched, and a webtask token would be leaked into the page.
    
## 🔗 References

https://auth0team.atlassian.net/browse/SEC-530
  
## 🎯 Testing
  
- We pushed this extension to our testing tenant manually. We were still able to log in as usual from the dashboard. We crafted a token according to the linked security ticket, and when posting it to `/callback`, we now get an error message saying that the issuer is invalid.
