### PR TITLE
Backport RTA issuer check to 2.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-authentication-api-debugger-extension",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "My extension for ..",
   "main": "index.js",
   "scripts": {

--- a/server/middleware/dashboardAdmins.js
+++ b/server/middleware/dashboardAdmins.js
@@ -1,5 +1,6 @@
 const url = require('url');
 const auth0 = require('auth0-oauth2-express');
+const jwt = require('jsonwebtoken');
 
 module.exports = function(domain, title, rta) {
   if (!domain) throw new Error('Domain is required');
@@ -12,7 +13,23 @@ module.exports = function(domain, title, rta) {
     audience: function() {
       return 'https://' + domain + '/api/v2/';
     },
-    rootTenantAuthority: rta
+    rootTenantAuthority: rta,
+    authenticatedCallback: function (req, res, accessToken, next) {
+      /**
+       * Note: We're normalizing the issuer because the access token `iss`
+       * ends in a slash whereas the `AUTH0_RTA` secret does not.
+       */
+      var expectedIssuer = rta.endsWith("/") ? rta : rta + "/";
+      var dtoken = jwt.decode(accessToken) || {};
+
+      if (dtoken.iss !== expectedIssuer) {
+        res.status(500);
+        return res.json({
+          message: "jwt issuer invalid. expected: " + expectedIssuer
+        });
+      }
+      return next();
+    },
   };
 
   const middleware = auth0(options);

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Auth0 Authentication API Debugger",
   "name": "auth0-authentication-api-debugger",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": "auth0",
   "useHashName": false,
   "description": "This extension allows you to test and debug the various Authentication API endpoints",


### PR DESCRIPTION
## ✏️ Changes
  
Backport the issuer check introduced in https://github.com/auth0-extensions/auth0-authentication-api-debugger-extension/pull/33
 
## 🔗 References
  
https://auth0team.atlassian.net/browse/SEC-530
  
