### PR TITLE
[2.0.x] Downgrade auth0 to 2.17 since 2.23 is not available in PSaaS.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-authentication-api-debugger-extension",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "My extension for ..",
   "main": "index.js",
   "scripts": {
@@ -17,7 +17,7 @@
   "license": "MIT",
   "auth0-extension": {
     "externals": [
-      "auth0@2.23.0",
+      "auth0@2.17.0",
       "auth0-extension-tools@1.3.2",
       "auth0-extension-express-tools@1.1.6",
       "auth0-oauth2-express@1.2.0",
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "auth0": "^2.23.0",
+    "auth0": "^2.17.0",
     "auth0-extension-express-tools": "^1.1.9",
     "auth0-extension-tools": "^1.3.3",
     "auth0-oauth2-express": "1.2.0",

--- a/server/index.js
+++ b/server/index.js
@@ -80,7 +80,7 @@ module.exports = (configProvider) => {
             __bypassIdTokenValidation: true
         });
 
-        const data = { refresh_token: req.body.refresh_token };
+        const data = { refresh_token: req.body.refresh_token, client_secret: req.body.client_secret };
         auth0.oauth.refreshToken(data, function (err, response) {
             if (err) {
                 const data = utils.tryParseJSON(err.message);

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Auth0 Authentication API Debugger",
   "name": "auth0-authentication-api-debugger",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "author": "auth0",
   "useHashName": false,
   "description": "This extension allows you to test and debug the various Authentication API endpoints",


### PR DESCRIPTION
## ✏️ Changes

When we released 2.0.4 last week to address a security issue, it was built on top of 2.0.3 which was never fully released. This change picks up 8e535e6 to downgrade auth0 to 2.17.0 like it was on master.  
  
## 🔗 References
  
https://auth0team.atlassian.net/browse/ESD-7704
  
## 🎯 Testing
  
I manually copied this code to a tenant in production and made sure the extension loaded properly.
   
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
